### PR TITLE
remove onpush for codeanalysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]


### PR DESCRIPTION
code analysis was failing on push to `main` with the following error - https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true

```
Run github/codeql-action/init@v1
Warning: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
RequestError [HttpError]: Resource not accessible by integration
    at /home/runner/work/_actions/github/codeql-action/v1/node_modules/@octokit/request/dist-node/index.js:66:23
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Job.doExecute (/home/runner/work/_actions/github/codeql-action/v1/node_modules/bottleneck/light.js:405:18) {
  status: 403,
  headers: {
    'access-control-allow-origin': '*',
    'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
    connection: 'close',
    'content-encoding': 'gzip',
    'content-security-policy': "default-src 'none'",
    'content-type': 'application/json; charset=utf-8',
    date: 'Sat, 16 Apr 2022 20:54:54 GMT',
    'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
    server: 'GitHub.com',
    'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
    'transfer-encoding': 'chunked',
    vary: 'Accept-Encoding, Accept, X-Requested-With',
    'x-content-type-options': 'nosniff',
    'x-frame-options': 'deny',
    'x-github-media-type': 'github.v3; format=json',
    'x-github-request-id': '07C5:21C1:2E83EE0:5BAE651:625B2D1E',
    'x-ratelimit-limit': '[10](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:10)00',
    'x-ratelimit-remaining': '996',
    'x-ratelimit-reset': '1650146093',
    'x-ratelimit-resource': 'core',
    'x-ratelimit-used': '4',
    'x-xss-protection': '0'
  },
  request: {
    method: 'PUT',
    url: 'https://api.github.com/repos/jsegal205/jimsegal-api/code-scanning/analysis/status',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'CodeQL-Action/1.1.8 octokit-core.js/3.1.2 Node.js/[12](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:12).22.7 (linux; x64)',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'
    },
    body: '{"workflow_run_id":2177907585,"workflow_name":"CodeQL","job_name":"analyze","analysis_key":".github/workflows/codeql-analysis.yml:analyze","commit_oid":"902e63bc89ca6fd3e2[15](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:15)c26c934032b85471e555","ref":"refs/heads/main","action_name":"init","action_ref":"v1","action_oid":"unknown","started_at":"2022-04-[16](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:16)T[20](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:20):54:53.465Z","action_started_at":"20[22](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:22)-04-16T20:54:53.[46](https://github.com/jsegal205/jimsegal-api/runs/6049864433?check_suite_focus=true#step:4:46)5Z","status":"starting","runner_os":"Linux","action_version":"1.1.8","cause":"CheckoutWrongHead","matrix_vars":"{\\n  \\"language\\": \\"javascript\\"\\n}","runner_arch":"X64"}',
    request: { agent: [Agent], hook: [Function: bound bound register] }
  },
  documentation_url: 'https://docs.github.com/rest'
}
Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
```

Removing triggering code analysis on push to `main`